### PR TITLE
More efficient pooling

### DIFF
--- a/models/layers/mesh_pool.py
+++ b/models/layers/mesh_pool.py
@@ -82,7 +82,7 @@ class MeshPool(nn.Module):
     def __clean_side(self, mesh, edge_id, mask, edge_groups, side):
         if mesh.edges_count <= self.__out_target:
             return False
-        invalid_edges = MeshPool.__get_invalids(mesh, edge_id, edge_groups, side)
+        invalid_edges = self.__get_invalids(mesh, edge_id, edge_groups, side)
         while len(invalid_edges) != 0 and mesh.edges_count > self.__out_target:
             self.__remove_triplete(mesh, mask, edge_groups, invalid_edges)
             if mesh.edges_count <= self.__out_target:
@@ -124,8 +124,7 @@ class MeshPool(nn.Module):
         mesh.edges_count -= 1
         return key_a
 
-    @staticmethod
-    def __get_invalids(mesh, edge_id, edge_groups, side):
+    def __get_invalids(self, mesh, edge_id, edge_groups, side):
         info = MeshPool.__get_face_info(mesh, edge_id, side)
         key_a, key_b, side_a, side_b, other_side_a, other_side_b, other_keys_a, other_keys_b = info
         shared_items = MeshPool.__get_shared_items(other_keys_a, other_keys_b)
@@ -141,12 +140,11 @@ class MeshPool(nn.Module):
             MeshPool.__redirect_edges(mesh, edge_id, side, update_key_a, update_side_a)
             MeshPool.__redirect_edges(mesh, edge_id, side + 1, update_key_b, update_side_b)
             MeshPool.__redirect_edges(mesh, update_key_a, MeshPool.__get_other_side(update_side_a), update_key_b, MeshPool.__get_other_side(update_side_b))
-            MeshPool.__union_groups(mesh, edge_groups, key_a, edge_id)
-            MeshPool.__union_groups(mesh, edge_groups, key_b, edge_id)
-            MeshPool.__union_groups(mesh, edge_groups, key_a, update_key_a)
-            MeshPool.__union_groups(mesh, edge_groups, middle_edge, update_key_a)
-            MeshPool.__union_groups(mesh, edge_groups, key_b, update_key_b)
-            MeshPool.__union_groups(mesh, edge_groups, middle_edge, update_key_b)
+            self.to_merge_edges.append((key_a, edge_id))
+            self.to_merge_edges.append((key_b, edge_id))
+            self.to_merge_edges.append((key_a, update_key_a))
+            self.to_merge_edges.append((middle_edge, update_key_a))
+            self.to_merge_edges.append((middle_edge, update_key_b))
             return [key_a, key_b, middle_edge]
 
     @staticmethod


### PR DESCRIPTION
First of all thank you for your work done in this project, it has been a huge help!

The current implementation calls `MeshUnion.union` a lot of times during each pooling step, which takes a lot of time. By storing all the source and target rows, we can vectorize the union operation, and achieve a ~2x speed-up in the training time.

Output from training human_seg before this change takes around 314 s per epoch:
```
saving the latest model (epoch 1, total_steps 8)
(epoch: 1, iters: 40, time: 0.840, data: 3.949) loss: 2.140 
(epoch: 1, iters: 80, time: 0.822, data: 0.011) loss: 1.898 
(epoch: 1, iters: 120, time: 0.833, data: 0.012) loss: 1.771 
(epoch: 1, iters: 160, time: 0.788, data: 0.012) loss: 1.831 
(epoch: 1, iters: 200, time: 0.786, data: 0.015) loss: 1.598 
(epoch: 1, iters: 240, time: 0.784, data: 0.012) loss: 1.485 
(epoch: 1, iters: 280, time: 0.771, data: 0.016) loss: 1.578 
(epoch: 1, iters: 320, time: 0.779, data: 0.011) loss: 1.392 
(epoch: 1, iters: 360, time: 0.775, data: 0.013) loss: 1.240 
saving the model at the end of epoch 1, iters 384
End of epoch 1 / 2100 	 Time Taken: 314 sec
learning rate = 0.0010000
Running Test
loaded mean / std from cache
loading the model from ./checkpoints\human_seg\latest_net.pth
epoch: 1, TEST ACC: [56.706 %]
```

After this change it takes around 149 s per epoch:
```
saving the latest model (epoch 1, total_steps 8)
(epoch: 1, iters: 40, time: 0.353, data: 3.925) loss: 2.087 
(epoch: 1, iters: 80, time: 0.412, data: 0.010) loss: 1.932 
(epoch: 1, iters: 120, time: 0.402, data: 0.022) loss: 1.822 
(epoch: 1, iters: 160, time: 0.369, data: 0.012) loss: 1.755 
(epoch: 1, iters: 200, time: 0.364, data: 0.012) loss: 1.702 
(epoch: 1, iters: 240, time: 0.358, data: 0.027) loss: 1.624 
(epoch: 1, iters: 280, time: 0.358, data: 0.014) loss: 1.503 
(epoch: 1, iters: 320, time: 0.359, data: 0.012) loss: 1.546 
(epoch: 1, iters: 360, time: 0.375, data: 0.010) loss: 1.364 
saving the model at the end of epoch 1, iters 384
End of epoch 1 / 2100 	 Time Taken: 149 sec
learning rate = 0.0010000
Running Test
loaded mean / std from cache
loading the model from ./checkpoints\human_seg\latest_net.pth
epoch: 1, TEST ACC: [66.507 %]
```

